### PR TITLE
add `for` to React.DOM.Props

### DIFF
--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -157,6 +157,9 @@ draggable = unsafeMkProps "draggable"
 encType :: String -> Props
 encType = unsafeMkProps "encType"
 
+for :: String -> Props
+for = unsafeMkProps "for"
+
 form :: String -> Props
 form = unsafeMkProps "form"
 


### PR DESCRIPTION
this property is used to specify what element a html label refers to